### PR TITLE
Added script dir to python path for multi file scripts

### DIFF
--- a/src/paramit/cli/__init__.py
+++ b/src/paramit/cli/__init__.py
@@ -527,8 +527,13 @@ def run_code(source_code: str, python_path: str, cwd: str, script_path: str) -> 
         # Write the __file__ variable at the top of the file to the original script path
         temp_file.write(f"__file__ = {repr(os.path.abspath(script_path))}\n")
 
+        script_dir = os.path.dirname(os.path.abspath(script_path))
+        
+        # Adjust the Python path to include the directory of the script
+        temp_file.write(f"import sys\nsys.path.insert(0, {repr(script_dir)})\n")
+        
         # Write the code to set the original directory as the working directory
-        temp_file.write(f"import os\nos.chdir({repr(os.path.dirname(os.path.abspath(script_path)))})\n")
+        temp_file.write(f"import os\nos.chdir({repr(script_dir)})\n")
 
         temp_file.write(source_code)
         temp_file_path = temp_file.name


### PR DESCRIPTION
This change resolves #57  by adding the original script directory to the python path.